### PR TITLE
Adding kernel timer capabilities

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -721,7 +721,8 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
     h += "TensileStatus generatedCallToFunction(\n"
     h += "    unsigned int *sizes,\n"
     h += "    DataType alpha,\n"
-    h += "    DataType beta );\n\n"
+    h += "    DataType beta, \n"
+    h += "    cl_event *outputEvent = nullptr );\n\n"
 
     for dataType in dataTypes:
       typeName = dataType.toCpp()
@@ -733,7 +734,8 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
       h += "inline TensileStatus generatedCallToFunction<%s>(\n" % typeName
       h += "    unsigned int *sizes,\n"
       h += "    %s alpha,\n" % typeName
-      h += "    %s beta ) {\n\n" % typeName
+      h += "    %s beta,\n" % typeName
+      h += "    cl_event *outputEvent ) {\n\n"
 
       h += "  unsigned int functionIdxForDataType = functionInfo[functionIdx][4];\n"
 
@@ -807,7 +809,7 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
         for i in range(0, problemType["TotalIndices"]):
           h += "        size%s,\n" % indexChars[i]
         h += "        stream,\n"
-        h += "        0, NULL, NULL); // events\n"
+        h += "        0, NULL, outputEvent); // events\n"
       if len(functionsForDataType) > 1:
         h += "  }\n" # close last if
       h += "};\n" # close callToFunction

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -590,10 +590,12 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
   ##############################################################################
   # Benchmarking and Validation Parameters
   ##############################################################################
-  h += "/* benchmarking parameters */\n"
-  h += "unsigned int numEnqueuesPerSync = %u;\n" \
+  h += "\n/* benchmarking parameters */\n"
+  h += "const bool measureKernelTime = %s;\n" \
+      % ("true" if globalParameters["KernelTime"] else "false")
+  h += "const unsigned int numEnqueuesPerSync = %u;\n" \
       % (globalParameters["EnqueuesPerSync"])
-  h += "unsigned int numSyncsPerBenchmark = %u;\n" \
+  h += "const unsigned int numSyncsPerBenchmark = %u;\n" \
       % (globalParameters["SyncsPerBenchmark"])
   h += "unsigned int numElementsToValidate = %s;\n" \
       % (str(globalParameters["NumElementsToValidate"]) \
@@ -648,7 +650,8 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
     h += "    unsigned int solutionIdx,\n"
     h += "    unsigned int *sizes,\n"
     h += "    DataType alpha,\n"
-    h += "    DataType beta ) {\n"
+    h += "    DataType beta, \n"
+    h += "    cl_event *outputEvent = nullptr ) {\n"
     h += "  // calculate parameters assuming packed data\n"
     # strides
     indexChars = globalParameters["IndexChars"]
@@ -706,7 +709,7 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
     for i in range(0, problemType["TotalIndices"]):
       h += "      size%s,\n" % indexChars[i]
     h += "      stream,\n"
-    h += "      0, NULL, NULL); // events\n"
+    h += "      0, NULL, outputEvent ); // events\n"
     h += "};\n"
     h += "\n"
   else:
@@ -827,4 +830,3 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
   clientParametersFile.write(CHeader)
   clientParametersFile.write(h)
   clientParametersFile.close()
-

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -651,7 +651,14 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
     h += "    unsigned int *sizes,\n"
     h += "    DataType alpha,\n"
     h += "    DataType beta, \n"
-    h += "    cl_event *outputEvent = nullptr ) {\n"
+    h += "    unsigned int numEvents = 0, \n"
+    if globalParameters["RuntimeLanguage"] == "OCL":
+      h += "    cl_event *event_wait_list = nullptr,\n"
+      h += "    cl_event *outputEvent = nullptr ) {\n"
+    else:
+      h += "    hipEvent_t *startEvent = nullptr,\n"
+      h += "    hipEvent_t *stopEvent = nullptr ) {\n"
+
     h += "  // calculate parameters assuming packed data\n"
     # strides
     indexChars = globalParameters["IndexChars"]
@@ -709,7 +716,11 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
     for i in range(0, problemType["TotalIndices"]):
       h += "      size%s,\n" % indexChars[i]
     h += "      stream,\n"
-    h += "      0, NULL, outputEvent ); // events\n"
+    if globalParameters["RuntimeLanguage"] == "OCL":
+       h += "      numEvents, event_wait_list, outputEvent ); // events\n"
+    else:
+       h += "      numEvents, startEvent, stopEvent); // events\n"
+
     h += "};\n"
     h += "\n"
   else:
@@ -722,7 +733,15 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
     h += "    unsigned int *sizes,\n"
     h += "    DataType alpha,\n"
     h += "    DataType beta, \n"
-    h += "    cl_event *outputEvent = nullptr );\n\n"
+    h += "    unsigned int numEvents = 0, \n"
+
+    if globalParameters["RuntimeLanguage"] == "OCL":
+      h += "    cl_event *event_wait_list = nullptr,\n"
+      h += "    cl_event *outputEvent = nullptr );\n\n"
+    else:
+      h += "    hipEvent_t *startEvent = nullptr,\n"
+      h += "    hipEvent_t *stopEvent = nullptr );\n\n"
+
 
     for dataType in dataTypes:
       typeName = dataType.toCpp()
@@ -735,7 +754,14 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
       h += "    unsigned int *sizes,\n"
       h += "    %s alpha,\n" % typeName
       h += "    %s beta,\n" % typeName
-      h += "    cl_event *outputEvent ) {\n\n"
+      h += "    unsigned int numEvents, \n"
+
+      if globalParameters["RuntimeLanguage"] == "OCL":
+        h += "    cl_event *event_wait_list,\n"
+        h += "    cl_event *outputEvent ) {\n\n"
+      else:
+        h += "    hipEvent_t *startEvent,\n"
+        h += "    hipEvent_t *stopEvent ) {\n\n"
 
       h += "  unsigned int functionIdxForDataType = functionInfo[functionIdx][4];\n"
 
@@ -809,7 +835,11 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
         for i in range(0, problemType["TotalIndices"]):
           h += "        size%s,\n" % indexChars[i]
         h += "        stream,\n"
-        h += "        0, NULL, outputEvent); // events\n"
+        if globalParameters["RuntimeLanguage"] == "OCL":
+           h += "        numEvents, event_wait_list, outputEvent); // events\n"
+        else:
+           h += "        numEvents, startEvent, stopEvent); // events\n"
+
       if len(functionsForDataType) > 1:
         h += "  }\n" # close last if
       h += "};\n" # close callToFunction

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -45,6 +45,8 @@ globalParameters["ForceRedoLibraryClient"] = True
 globalParameters["EnqueuesPerSync"] = 1
 globalParameters["SyncsPerBenchmark"] = 4
 globalParameters["PinClocks"] = False
+globalParameters["KernelTime"] = False
+
 # file heirarchy
 globalParameters["ShortNames"] = False
 globalParameters["MergeFiles"] = True
@@ -323,4 +325,3 @@ def ensurePath( path ):
 CMakeHeader = "# Header\n\n"
 CHeader = "// Header\n\n"
 HR = "################################################################################"
-

--- a/Tensile/Configs/sgemm.yaml
+++ b/Tensile/Configs/sgemm.yaml
@@ -15,6 +15,7 @@ GlobalParameters:
   Platform: 0
   Device: 0
   DataInitType: 0
+  KernelTime: True
 
 BenchmarkProblems:
   # sgemm NN

--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -271,6 +271,8 @@ class SolutionWriter:
         s += "%stensileStatusCheck(status);\n" % (t)
 
       else:
+        s += "%sif( inputEvents != nullptr )\n" % (t)
+        s += "%s  hipEventRecord(inputEvents[enqueueIdx], stream );\n" % (t)
         s += "%shipLaunchKernel(\n" % (t)
         t += "  "
         s += "%sHIP_KERNEL_NAME(%s),\n" % (t, kernelName)
@@ -296,6 +298,8 @@ class SolutionWriter:
           s += "%ssizes[kernelIdx][enqueueIdx][%u]%s\n" \
               % (t, i, "" if lastParam else "," )
         s += "    );\n"
+        s += "%sif( outputEvent != nullptr )\n" % (t)
+        s += "%s  hipEventRecord(outputEvent[enqueueIdx], stream );\n" % (t)
       s += "  }\n"
     s += "\n"
     s += "  return tensileStatusSuccess;\n"

--- a/Tensile/Source/Client.cpp
+++ b/Tensile/Source/Client.cpp
@@ -184,8 +184,15 @@ void initControls() {
   std::cout << "Device: \"" << deviceName << "\"" << std::endl;
   context = clCreateContext(nullptr, 1, &device, nullptr, nullptr, &status);
   tensileStatusCheck(status);
-  stream = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+
+  if (measureKernelTime) {
+      stream = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+  }
+  else {
+      stream = clCreateCommandQueue(context, device, 0x0, &status);
+  }
   tensileStatusCheck(status);
+
   delete[] devices;
   delete[] platforms;
 #elif Tensile_RUNTIME_LANGUAGE_HIP
@@ -218,4 +225,3 @@ void destroyControls() {
   hipStreamDestroy(stream);
 #endif
 }
-

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -195,7 +195,7 @@ bool callLibrary(
       << std::setw(9) << std::fixed << std::setprecision(3) << timeMs
       << " ms | v: " << (numInvalids ? "FAILED" : "PASSED")
       << " " << (numChecked-numInvalids) << "/" << numChecked;
-    std::cout << " | api:" << std::setw(6) << std::fixed 
+    std::cout << " | api:" << std::setw(6) << std::fixed
       << std::setprecision(3) << apiTimeUs << " us";
     std::cout << std::endl;
   } else {
@@ -212,7 +212,7 @@ bool callLibrary(
     if (newFastest) {
       std::cout << "*";
     }
-    std::cout << " | api:" << std::setw(6) << std::fixed 
+    std::cout << " | api:" << std::setw(6) << std::fixed
       << std::setprecision(3) << apiTimeUs << " us";
     std::cout << std::endl;
   }
@@ -220,6 +220,32 @@ bool callLibrary(
 } // callLibrary
 #endif
 
+
+/*******************************************************************************
+* Given a finished/synced OpenCL event
+* return performance in nano-seconds of time executing the kernel associated with the event
+******************************************************************************/
+cl_ulong getEventDeltaTime( cl_event event )
+{
+    cl_ulong start, end = 0;
+    cl_int cl_error = CL_SUCCESS;
+
+    if (cl_error = ::clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &start, NULL) != CL_SUCCESS)
+    {
+        std::cout << "::clGetEventProfilingInfo error code: " << cl_error << std::endl;
+
+        start = 0;
+    }
+
+    if (cl_error = ::clGetEventProfilingInfo(event, CL_PROFILING_COMMAND_END, sizeof(cl_ulong), &end, NULL) != CL_SUCCESS)
+    {
+        std::cout << "::clGetEventProfilingInfo error code: " << cl_error << std::endl;
+
+        end = 0;
+    }
+
+    return (end - start);
+}
 
 /*******************************************************************************
  * benchmark all solutions for problem size
@@ -340,23 +366,53 @@ bool benchmarkAllSolutionsForSize(
       if (numInvalids) returnInvalids = true;
     } // if numElementsToValidate > 0
 
+#if Tensile_RUNTIME_LANGUAGE_OCL
+    cl_event l_eventNDRange[numSyncsPerBenchmark][numEnqueuesPerSync];
+#else
+    static_assert("HIP events not implemented");
+#endif
+
     // time solution
     timer.start();
     for (unsigned int syncIdx = 0; syncIdx < numSyncsPerBenchmark; syncIdx++) {
       for (unsigned int enqIdx = 0; enqIdx < numEnqueuesPerSync; enqIdx++) {
-        generatedCallToSolution( solutionIdx , sizes, alpha, beta );
+          if (measureKernelTime)
+            generatedCallToSolution( solutionIdx , sizes, alpha, beta, &l_eventNDRange[syncIdx][enqIdx] );
+          else
+            generatedCallToSolution( solutionIdx, sizes, alpha, beta );
       }
       // sync
 #if Tensile_RUNTIME_LANGUAGE_OCL
-      status = clFinish(stream); tensileStatusCheck(status);
+      status = clFinish(stream);
 #else
-      status = hipStreamSynchronize(stream); tensileStatusCheck(status);
+      status = hipStreamSynchronize(stream);
 #endif
       tensileStatusCheck(status);
     } // sync loop
-    double timeMs = timer.elapsed_ms()
-      / numSyncsPerBenchmark / numEnqueuesPerSync;
-    double gflops = totalFlops / timeMs / 1000000.0;
+
+    double timeNs = 0.0;
+#if Tensile_RUNTIME_LANGUAGE_OCL
+    if (measureKernelTime) {
+        // Loop through the multi-dimensional event array and collect kernel performance data
+        // Release events when done with them
+        cl_ulong kernel_time_sum = 0;
+        for (auto& event_array : l_eventNDRange) {
+            for (auto event : event_array) {
+                // getEventDeltaTime returns unsigned long in nano-seconds
+                kernel_time_sum += getEventDeltaTime(event);
+                ::clReleaseEvent(event);
+            }
+        }
+        timeNs = static_cast<double>(kernel_time_sum);
+    } else {
+        timeNs = timer.elapsed_ns();
+    }
+
+#endif
+
+    timeNs /= (numSyncsPerBenchmark / numEnqueuesPerSync);
+
+    double gflops = totalFlops / timeNs;
     bool newFastest = false;
     if (gflops > fastestGFlops) {
       fastestGFlops = gflops;
@@ -375,7 +431,7 @@ bool benchmarkAllSolutionsForSize(
         std::cout << " ";
       }
       std::cout << " |"
-        << std::setw(9) << std::fixed << std::setprecision(3) << timeMs << " ms | v: " << (numInvalids ? "FAILED" : "PASSED")
+        << std::setw(9) << std::fixed << std::setprecision(3) << timeNs * TensileTimer::reciprical_thousand << " us | v: " << (numInvalids ? "FAILED" : "PASSED")
         << " " << (numChecked-numInvalids) << "/" << numChecked;
       if (numInvalids > 0) {
         std::cout << " - " << solutionNames[solutionIdx];
@@ -391,7 +447,7 @@ bool benchmarkAllSolutionsForSize(
         std::cout << " ";
       }
       std::cout << " |"
-        << std::setw(9) << std::fixed << std::setprecision(3) << timeMs << " ms" << std::endl;
+        << std::setw(9) << std::fixed << std::setprecision(3) << timeNs * TensileTimer::reciprical_thousand << " us" << std::endl;
     }
     if (numInvalids > 0) {
       gflops = -1.0;
@@ -736,4 +792,3 @@ void parseCommandLineParameters( int argc, char *argv[] ) {
   }
 #endif
 }
-

--- a/Tensile/Source/Tools.cpp
+++ b/Tensile/Source/Tools.cpp
@@ -90,9 +90,10 @@ double TensileTimer::elapsed_ns() {
 
     // (currentTime.tv_nsec - startTime.tv_nsec) might be negative, if a 'second' boundary crossed and tv_nsec reset to 0
     // Convert to double type before subtracting to properly borrow from seconds when nano-seconds would be negative
+
     double d_startTime = static_cast<double>(startTime.tv_sec)*billion + static_cast<double>(startTime.tv_nsec);
     double d_currentTime = static_cast<double>(currentTime.tv_sec)*billion + static_cast<double>(currentTime.tv_nsec);
-    double return_elapsed_ns = d_currentTime - d_startTime;
+    return_elapsed_ns = d_currentTime - d_startTime;
 #endif
     return return_elapsed_ns;
 }

--- a/Tensile/Source/Tools.h
+++ b/Tensile/Source/Tools.h
@@ -39,12 +39,22 @@ public:
   double elapsed_sec();
   double elapsed_ms();
   double elapsed_us();
+  double elapsed_ns();
+
+  static const double billion;
+  static const double million;
+  static const double thousand;
+  static const double reciprical_billion;
+  static const double reciprical_million;
+  static const double reciprical_thousand;
 
 private:
 #ifdef WIN32
   LARGE_INTEGER startTime;
   LARGE_INTEGER frequency; 
 #else
+    const clockid_t clock_type = CLOCK_MONOTONIC;
+    //const clockid_t clock_type = CLOCK_MONOTONIC_RAW;
   timespec startTime;
 #endif
 };


### PR DESCRIPTION
host based API timers are still default.  Functionality to enable/disable kernel timing is controlled by a new yml variable called KernelTime.  Right now, a single yaml file turns kernel timers on, sgemm.yml.

Bug fix for host based timers on the linux code path.  Default resolution in program logic is now nano-seconds, and console output is in micro-seconds.